### PR TITLE
fix(examples): add required image owner filter

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,6 +14,7 @@ data "alicloud_instance_types" "this" {
 
 data "alicloud_images" "ubuntu" {
   most_recent   = true
+  owners        = "system"
   instance_type = data.alicloud_instance_types.this.instance_types[0].id
 }
 


### PR DESCRIPTION
## Summary

Add the required owner filter to the complete example's ECS image query.

## Root cause

The current provider requires at least one image selector such as `owners`, `image_owner_id`, or `name_regex`; the example supplied none.

## Change

Set `owners = "system"` on the example data source.

## Validation

- `terraform fmt -check -recursive`
- TFLint with all configured rules
- `terraform init -upgrade`
- `terraform validate`
- `git diff --check`

Source: ODPS regression partition `20260723`.

Compatibility: example-only filter addition; no module interface or managed resource changed. Release impact: PATCH.

The PR remains Draft while remote regression checks run.
